### PR TITLE
Fix the tests on Python 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 docutils==0.12
-flake8==2.4.1
-isort==4.2.2
+flake8==2.5.4
+isort==4.2.5
 pathlib==1.0.1
 pep8==1.7.0
 py==1.4.31
 pyflakes==1.1.0
-Pygments==2.0.2
-pytest==2.8.5
+Pygments==2.1.3
+pytest==2.9.1
 six==1.10.0
-tox==2.1.1
-wheel==0.23.0

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -27,7 +27,7 @@ def teardown_module(module):
 
 def run_flake8(file_contents):
     with open(str(TMP_DIR / "example.py"), 'w') as tempf:
-        tempf.write(dedent(file_contents).strip() + '\n')
+        tempf.write(dedent(file_contents.lstrip('\n')).strip() + '\n')
 
     orig_dir = os.getcwd()
     os.chdir(str(TMP_DIR))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,34,35}
+    py{27,35}
 
 [testenv]
 setenv =


### PR DESCRIPTION
For some reason the column numbers are off on 3.4 only. Maybe dedent had a bug.