### PR TITLE
Make C402 only respond to generators of two-tuples

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,8 +8,8 @@ Pending Release
 * New release notes here
 * Don't allow installation with Flake8 3.2.0 which doesn't enable the plugin.
   This bug was fixed in Flake8 3.2.1.
-* Fix C402 false positive where a function call prevents using dict
-  comprehension.
+* Prevent false positives of ``C402`` from generators of expressions that
+  aren't two-tuples.
 
 1.2.1 (2016-06-27)
 ------------------

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -53,7 +53,8 @@ class ComprehensionChecker(object):
 
                 elif (
                     isinstance(node.args[0], ast.GeneratorExp) and
-                    not isinstance(node.args[0].elt, ast.Call) and
+                    isinstance(node.args[0].elt, ast.Tuple) and
+                    len(node.args[0].elt.elts) == 2 and
                     node.func.id == 'dict'
                 ):
                     yield (

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -120,8 +120,16 @@ def test_C402_pass_1():
 
 def test_C402_pass_2():
     errors = run_flake8("""
-        lst = ['a=1', 'b=2', 'c=3']
-        dict(pair.split('=') for pair in lst)
+        foo = ['a=1', 'b=2', 'c=3']
+        dict(pair.split('=') for pair in foo)
+    """)
+    assert errors == []
+
+
+def test_C402_pass_3():
+    errors = run_flake8("""
+        foo = [('a', 1), ('b', 2), ('c', 3)]
+        dict(pair for pair in foo if pair[1] % 2 == 0)
     """)
     assert errors == []
 
@@ -145,16 +153,6 @@ def test_C402_fail_2():
     """)
     assert errors == [
         'example.py:1:10: C402 Unnecessary generator - rewrite as a dict comprehension.',
-    ]
-
-
-def test_C402_fail_3():
-    errors = run_flake8("""
-        lst = [('a', 1), ('b', 2), ('c', 3)]
-        dict(pair for pair in lst if pair[1] % 2 == 0)
-    """)
-    assert errors == [
-        'example.py:2:1: C402 Unnecessary generator - rewrite as a dict comprehension.',
     ]
 
 


### PR DESCRIPTION
Follow up to #53 as per code review. In general we can't find other generators that can be converted to `dict` comprehensions, so best to only complain about the ones that we're sure can be.