### PR TITLE
Add rule to complain about list comprehension in call to list()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Pending Release
 
 * ``C408`` rule that complains about using ``tuple()``, ``list()``, or
   ``dict()`` instead of a literal.
+* ``C411`` rule that complains about using list comprehension inside a
+  ``list()`` call.
 
 1.3.0 (2017-05-01)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ C405 Unnecessary (list/tuple) literal - rewrite as a set literal.
 C406 Unnecessary (list/tuple) literal - rewrite as a dict literal.
 C407 Unnecessary list comprehension - '<builtin>' can take a generator.
 C408 Unnecessary (dict/list/tuple) call - rewrite as a literal.
+C411 Unnecessary list call - remove the outer call to list().
 ==== ====
 
 Examples
@@ -117,3 +118,11 @@ rebound. Same for the other two basic types here. For example:
 * ``dict()`` is better as ``{}``
 * ``list()`` is better as ``[]``
 * ``tuple()`` is better as ``()``
+
+C411: Unnecessary list call - remove the outer call to list().
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's unnecessary to use a ``list`` around list comprehension, since it is
+equivalent without it. For example:
+
+* ``list([f(x) for x in foo])`` is better as ``[f(x) for x in foo]``

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -28,6 +28,7 @@ class ComprehensionChecker(object):
         'C406': 'C406 Unnecessary {type} literal - rewrite as a dict literal.',
         'C407': "C407 Unnecessary list comprehension - '{func}' can take a generator.",
         'C408': "C408 Unnecessary {type} call - rewrite as a literal.",
+        'C411': 'C411 Unnecessary list call - remove the outer call to list().',
     }
 
     def run(self):
@@ -71,9 +72,10 @@ class ComprehensionChecker(object):
                 elif (
                     n_args == 1 and
                     isinstance(node.args[0], ast.ListComp) and
-                    node.func.id in ('set', 'dict')
+                    node.func.id in ('list', 'set', 'dict')
                 ):
                     msg_key = {
+                        'list': 'C411',
                         'set': 'C403',
                         'dict': 'C404',
                     }[node.func.id]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -376,3 +376,19 @@ def test_C408_fail_4():
     assert errors == [
         "example.py:1:1: C408 Unnecessary dict call - rewrite as a literal."
     ]
+
+
+def test_C411_pass_1():
+    errors = run_flake8("""
+        [x for x in range(10)]
+    """)
+    assert errors == []
+
+
+def test_C411_fail_1():
+    errors = run_flake8("""
+        list([x for x in range(10)])
+    """)
+    assert errors == [
+        'example.py:1:1: C411 Unnecessary list call - remove the outer call to list().',
+    ]


### PR DESCRIPTION
I wrote this change anticipating it will need to be rebased on #55.