### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ universal = 1
 [flake8]
 max_line_length = 120
 
+[metadata]
+license_file = LICENSE
+
 [isort]
 multi_line_output = 5
 known_standard_library = pathlib
@@ -13,4 +16,3 @@ not_skip = __init__.py
 paths = flake8_comprehensions.py
         setup.py
         test_flake8_comprehensions.py
-


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file