### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ flake8-comprehensions
 =====================
 
 .. image:: https://img.shields.io/pypi/v/flake8-comprehensions.svg
-        :target: https://pypi.python.org/pypi/flake8-comprehensions
+        :target: https://pypi.org/project/flake8-comprehensions/
 
 .. image:: https://img.shields.io/travis/adamchainz/flake8-comprehensions.svg
         :target: https://travis-ci.org/adamchainz/flake8-comprehensions


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html