### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 1.4.1 (2017-05-17)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,6 @@ flake8-comprehensions
 A `flake8 <https://flake8.readthedocs.io/en/latest/index.html>`_ plugin that
 helps you write better list/set/dict comprehensions.
 
-* Free software: ISC license
-
 Installation
 ------------
 
@@ -22,8 +20,10 @@ Install from ``pip`` with:
 
      pip install flake8-comprehensions
 
-It will then automatically be run as part of ``flake8``; you can check it has
-been picked up with:
+Python 3.4+ supported.
+
+When installed it will automatically be run as part of ``flake8``; you can
+check it is being picked up with:
 
 .. code-block:: sh
 

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import ast
 
 __author__ = 'Adam Johnson'

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,9 @@
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
-modernize
 multilint
 pathlib
 pytest
 pytest-flake8dir
 Pygments
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,19 +6,13 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pathlib==1.0.1
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
@@ -27,5 +21,4 @@ pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest-flake8dir==1.3.0
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest, pytest-flake8dir

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -16,10 +12,10 @@ def get_version(filename):
 version = get_version('flake8_comprehensions.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 setup(
@@ -41,7 +37,7 @@ setup(
     install_requires=[
         'flake8!=3.2.0',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="ISCL",
     zip_safe=False,
     keywords='flake8, comprehensions, list comprehension, set comprehension, '
@@ -52,8 +48,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test_flake8_comprehensions.py
+++ b/test_flake8_comprehensions.py
@@ -1,7 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 def test_C400_pass_1(flake8dir):
     flake8dir.make_example_py("""
         foo = [x for x in range(10)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,3},
-    py{27,3}-codestyle
+    py3,
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -9,13 +9,6 @@ setenv =
 install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = pytest {posargs}
-
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires` and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2