### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ flake8-comprehensions
 .. image:: https://img.shields.io/travis/adamchainz/flake8-comprehensions.svg
         :target: https://travis-ci.org/adamchainz/flake8-comprehensions
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 A `flake8 <https://flake8.readthedocs.io/en/latest/index.html>`_ plugin that
 helps you write better list/set/dict comprehensions.
 

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -1,52 +1,49 @@
 import ast
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '2.1.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "2.1.0"
 
 
 class ComprehensionChecker:
     """
     Flake8 plugin to help you write better list/set/dict comprehensions.
     """
-    name = 'flake8-comprehensions'
+
+    name = "flake8-comprehensions"
     version = __version__
 
     def __init__(self, tree, *args, **kwargs):
         self.tree = tree
 
     messages = {
-        'C400': 'C400 Unnecessary generator - rewrite as a list comprehension.',
-        'C401': 'C401 Unnecessary generator - rewrite as a set comprehension.',
-        'C402': 'C402 Unnecessary generator - rewrite as a dict comprehension.',
-        'C403': 'C403 Unnecessary list comprehension - rewrite as a set comprehension.',
-        'C404': 'C404 Unnecessary list comprehension - rewrite as a dict comprehension.',
-        'C405': 'C405 Unnecessary {type} literal - ',
-        'C406': 'C406 Unnecessary {type} literal - ',
-        'C407': "C407 Unnecessary list comprehension - '{func}' can take a generator.",
-        'C408': "C408 Unnecessary {type} call - rewrite as a literal.",
-        'C409': 'C409 Unnecessary {type} passed to tuple() - ',
-        'C410': 'C410 Unnecessary {type} passed to list() - ',
-        'C411': 'C411 Unnecessary list call - remove the outer call to list().',
+        "C400": "C400 Unnecessary generator - rewrite as a list comprehension.",
+        "C401": "C401 Unnecessary generator - rewrite as a set comprehension.",
+        "C402": "C402 Unnecessary generator - rewrite as a dict comprehension.",
+        "C403": "C403 Unnecessary list comprehension - rewrite as a set comprehension.",
+        "C404": (
+            "C404 Unnecessary list comprehension - rewrite as a dict comprehension."
+        ),
+        "C405": "C405 Unnecessary {type} literal - ",
+        "C406": "C406 Unnecessary {type} literal - ",
+        "C407": "C407 Unnecessary list comprehension - '{func}' can take a generator.",
+        "C408": "C408 Unnecessary {type} call - rewrite as a literal.",
+        "C409": "C409 Unnecessary {type} passed to tuple() - ",
+        "C410": "C410 Unnecessary {type} passed to list() - ",
+        "C411": "C411 Unnecessary list call - remove the outer call to list().",
     }
 
     def run(self):
         for node in ast.walk(self.tree):
-            if (
-                isinstance(node, ast.Call) and
-                isinstance(node.func, ast.Name)
-            ):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
                 n_args = len(node.args)
 
                 if (
-                    n_args == 1 and
-                    isinstance(node.args[0], ast.GeneratorExp) and
-                    node.func.id in ('list', 'set')
+                    n_args == 1
+                    and isinstance(node.args[0], ast.GeneratorExp)
+                    and node.func.id in ("list", "set")
                 ):
-                    msg_key = {
-                        'list': 'C400',
-                        'set': 'C401',
-                    }[node.func.id]
+                    msg_key = {"list": "C400", "set": "C401"}[node.func.id]
                     yield (
                         node.lineno,
                         node.col_offset,
@@ -55,29 +52,27 @@ class ComprehensionChecker:
                     )
 
                 elif (
-                    n_args == 1 and
-                    isinstance(node.args[0], ast.GeneratorExp) and
-                    isinstance(node.args[0].elt, ast.Tuple) and
-                    len(node.args[0].elt.elts) == 2 and
-                    node.func.id == 'dict'
+                    n_args == 1
+                    and isinstance(node.args[0], ast.GeneratorExp)
+                    and isinstance(node.args[0].elt, ast.Tuple)
+                    and len(node.args[0].elt.elts) == 2
+                    and node.func.id == "dict"
                 ):
                     yield (
                         node.lineno,
                         node.col_offset,
-                        self.messages['C402'],
+                        self.messages["C402"],
                         type(self),
                     )
 
                 elif (
-                    n_args == 1 and
-                    isinstance(node.args[0], ast.ListComp) and
-                    node.func.id in ('list', 'set', 'dict')
+                    n_args == 1
+                    and isinstance(node.args[0], ast.ListComp)
+                    and node.func.id in ("list", "set", "dict")
                 ):
-                    msg_key = {
-                        'list': 'C411',
-                        'set': 'C403',
-                        'dict': 'C404',
-                    }[node.func.id]
+                    msg_key = {"list": "C411", "set": "C403", "dict": "C404"}[
+                        node.func.id
+                    ]
                     yield (
                         node.lineno,
                         node.col_offset,
@@ -85,67 +80,80 @@ class ComprehensionChecker:
                         type(self),
                     )
 
-                elif (
-                    n_args == 1 and
-                    (isinstance(node.args[0], ast.Tuple) and node.func.id == 'tuple' or
-                     isinstance(node.args[0], ast.List) and node.func.id == 'list')
+                elif n_args == 1 and (
+                    isinstance(node.args[0], ast.Tuple)
+                    and node.func.id == "tuple"
+                    or isinstance(node.args[0], ast.List)
+                    and node.func.id == "list"
                 ):
-                    suffix = 'remove the outer call to {func}().'
+                    suffix = "remove the outer call to {func}()."
+                    msg_key = {"tuple": "C409", "list": "C410"}[node.func.id]
+                    msg = self.messages[msg_key] + suffix
+                    yield (
+                        node.lineno,
+                        node.col_offset,
+                        msg.format(
+                            type=type(node.args[0]).__name__.lower(), func=node.func.id
+                        ),
+                        type(self),
+                    )
+
+                elif (
+                    n_args == 1
+                    and isinstance(node.args[0], (ast.Tuple, ast.List))
+                    and node.func.id in ("tuple", "list", "set", "dict")
+                ):
+                    suffix = "rewrite as a {func} literal."
                     msg_key = {
-                        'tuple': 'C409',
-                        'list': 'C410',
+                        "tuple": "C409",
+                        "list": "C410",
+                        "set": "C405",
+                        "dict": "C406",
                     }[node.func.id]
                     msg = self.messages[msg_key] + suffix
                     yield (
                         node.lineno,
                         node.col_offset,
-                        msg.format(type=type(node.args[0]).__name__.lower(), func=node.func.id),
+                        msg.format(
+                            type=type(node.args[0]).__name__.lower(), func=node.func.id
+                        ),
                         type(self),
                     )
 
                 elif (
-                    n_args == 1 and
-                    isinstance(node.args[0], (ast.Tuple, ast.List)) and
-                    node.func.id in ('tuple', 'list', 'set', 'dict')
-                ):
-                    suffix = 'rewrite as a {func} literal.'
-                    msg_key = {
-                        'tuple': 'C409',
-                        'list': 'C410',
-                        'set': 'C405',
-                        'dict': 'C406',
-                    }[node.func.id]
-                    msg = self.messages[msg_key] + suffix
-                    yield (
-                        node.lineno,
-                        node.col_offset,
-                        msg.format(type=type(node.args[0]).__name__.lower(), func=node.func.id),
-                        type(self),
+                    n_args == 1
+                    and isinstance(node.args[0], ast.ListComp)
+                    and node.func.id
+                    in (
+                        "all",
+                        "any",
+                        "enumerate",
+                        "frozenset",
+                        "max",
+                        "min",
+                        "sorted",
+                        "sum",
+                        "tuple",
                     )
-
-                elif (
-                    n_args == 1 and
-                    isinstance(node.args[0], ast.ListComp) and
-                    node.func.id in ('all', 'any', 'enumerate', 'frozenset', 'max', 'min', 'sorted', 'sum', 'tuple')
                 ):
 
                     yield (
                         node.lineno,
                         node.col_offset,
-                        self.messages['C407'].format(func=node.func.id),
+                        self.messages["C407"].format(func=node.func.id),
                         type(self),
                     )
 
                 elif (
-                    n_args == 0 and
-                    not has_star_args(node) and
-                    not has_keyword_args(node) and
-                    node.func.id in ('tuple', 'list', 'dict')
+                    n_args == 0
+                    and not has_star_args(node)
+                    and not has_keyword_args(node)
+                    and node.func.id in ("tuple", "list", "dict")
                 ):
                     yield (
                         node.lineno,
                         node.col_offset,
-                        self.messages['C408'].format(type=node.func.id),
+                        self.messages["C408"].format(type=node.func.id),
                         type(self),
                     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,9 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,9 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,9 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -115,6 +126,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 isort
 multilint
 pathlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,18 @@
 [flake8]
-max_line_length = 120
-
-[metadata]
-license_file = LICENSE
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 
 [isort]
 include_trailing_comma = True
-multi_line_output = 5
-known_standard_library = pathlib
+force_grid_wrap = 0
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
+
+[metadata]
+license_file = LICENSE
 
 [tool:multilint]
 paths = flake8_comprehensions.py

--- a/setup.py
+++ b/setup.py
@@ -4,54 +4,50 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('flake8_comprehensions.py')
+version = get_version("flake8_comprehensions.py")
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
+with open("HISTORY.rst", "r") as history_file:
     history = history_file.read()
 
 setup(
-    name='flake8-comprehensions',
+    name="flake8-comprehensions",
     version=version,
-    description='A flake8 plugin to help you write better list/set/dict '
-                'comprehensions.',
-    long_description=readme + '\n\n' + history,
+    description="A flake8 plugin to help you write better list/set/dict "
+    "comprehensions.",
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/flake8-comprehensions',
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/flake8-comprehensions",
     entry_points={
-        'flake8.extension': [
-            'C4 = flake8_comprehensions:ComprehensionChecker',
-        ],
+        "flake8.extension": ["C4 = flake8_comprehensions:ComprehensionChecker"]
     },
-    py_modules=['flake8_comprehensions'],
+    py_modules=["flake8_comprehensions"],
     include_package_data=True,
-    install_requires=[
-        'flake8!=3.2.0',
-    ],
-    python_requires='>=3.5',
+    install_requires=["flake8!=3.2.0"],
+    python_requires=">=3.5",
     license="ISCL",
     zip_safe=False,
-    keywords='flake8, comprehensions, list comprehension, set comprehension, '
-             'dict comprehension',
+    keywords="flake8, comprehensions, list comprehension, set comprehension, "
+    "dict comprehension",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Flake8',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Flake8",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_flake8_comprehensions.py
+++ b/test_flake8_comprehensions.py
@@ -1,504 +1,627 @@
 def test_C400_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = [x for x in range(10)]
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C400_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list(x for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C400 Unnecessary generator - rewrite as a list comprehension.',
+        "./example.py:1:7: C400 Unnecessary generator - rewrite as a list "
+        + "comprehension."
     ]
 
 
 def test_C400_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foobar = list(
             str(x)
             for x
             in range(10)
         )
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:10: C400 Unnecessary generator - rewrite as a list comprehension.',
+        "./example.py:1:10: C400 Unnecessary generator - rewrite as a list "
+        + "comprehension."
     ]
 
 
 def test_C401_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = {x for x in range(10)}
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C401_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set(x for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C401 Unnecessary generator - rewrite as a set comprehension.',
+        "./example.py:1:7: C401 Unnecessary generator - rewrite as a set "
+        + "comprehension."
     ]
 
 
 def test_C401_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foobar = set(
             str(x) for x
             in range(10)
         )
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:10: C401 Unnecessary generator - rewrite as a set comprehension.',
+        "./example.py:1:10: C401 Unnecessary generator - rewrite as a set "
+        + "comprehension."
     ]
 
 
 def test_C402_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = {x: str(x) for x in range(10)}
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C402_pass_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = ['a=1', 'b=2', 'c=3']
         dict(pair.split('=') for pair in foo)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C402_pass_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = [('a', 1), ('b', 2), ('c', 3)]
         dict(pair for pair in foo if pair[1] % 2 == 0)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C402_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict((x, str(x)) for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C402 Unnecessary generator - rewrite as a dict comprehension.',
+        "./example.py:1:7: C402 Unnecessary generator - rewrite as a dict "
+        + "comprehension."
     ]
 
 
 def test_C402_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foobar = dict(
             (x, str(x))
             for x
             in range(10)
         )
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:10: C402 Unnecessary generator - rewrite as a dict comprehension.',
+        "./example.py:1:10: C402 Unnecessary generator - rewrite as a dict "
+        + "comprehension."
     ]
 
 
 def test_C403_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = {x for x in range(10)}
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C403_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C403 Unnecessary list comprehension - rewrite as a set comprehension.',
+        "./example.py:1:7: C403 Unnecessary list comprehension - rewrite as a "
+        + "set comprehension."
     ]
 
 
 def test_C404_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = {x: x for x in range(10)}
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C404_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict([(x, x) for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C404 Unnecessary list comprehension - rewrite as a dict comprehension.',
+        "./example.py:1:7: C404 Unnecessary list comprehension - rewrite as a "
+        + "dict comprehension."
     ]
 
 
 def test_C405_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set(range)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C405_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set([])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C405 Unnecessary list literal - rewrite as a set literal.',
+        "./example.py:1:7: C405 Unnecessary list literal - rewrite as a set "
+        + "literal."
     ]
 
 
 def test_C405_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set([1])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C405 Unnecessary list literal - rewrite as a set literal.',
+        "./example.py:1:7: C405 Unnecessary list literal - rewrite as a set "
+        + "literal."
     ]
 
 
 def test_C405_fail_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set(())
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C405 Unnecessary tuple literal - rewrite as a set literal.',
+        "./example.py:1:7: C405 Unnecessary tuple literal - rewrite as a set "
+        + "literal."
     ]
 
 
 def test_C405_fail_4(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = set((1,))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C405 Unnecessary tuple literal - rewrite as a set literal.',
+        "./example.py:1:7: C405 Unnecessary tuple literal - rewrite as a set "
+        + "literal."
     ]
 
 
 def test_C406_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict(range)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C406_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict([])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C406 Unnecessary list literal - rewrite as a dict literal.',
+        "./example.py:1:7: C406 Unnecessary list literal - rewrite as a dict "
+        + "literal."
     ]
 
 
 def test_C406_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict([(1, 2)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C406 Unnecessary list literal - rewrite as a dict literal.',
+        "./example.py:1:7: C406 Unnecessary list literal - rewrite as a dict "
+        + "literal."
     ]
 
 
 def test_C406_fail_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict(())
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C406 Unnecessary tuple literal - rewrite as a dict literal.',
+        "./example.py:1:7: C406 Unnecessary tuple literal - rewrite as a dict "
+        + "literal."
     ]
 
 
 def test_C406_fail_4(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = dict(((1, 2),))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C406 Unnecessary tuple literal - rewrite as a dict literal.',
+        "./example.py:1:7: C406 Unnecessary tuple literal - rewrite as a dict "
+        + "literal."
     ]
 
 
 def test_C407_sum_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = sum(x for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C407_sum_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = sum([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:7: C407 Unnecessary list comprehension - 'sum' can take a generator.",
+        "./example.py:1:7: C407 Unnecessary list comprehension - 'sum' can take "
+        + "a generator."
     ]
 
 
 def test_C407_max_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = max([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:7: C407 Unnecessary list comprehension - 'max' can take a generator.",
+        "./example.py:1:7: C407 Unnecessary list comprehension - 'max' can take "
+        + "a generator."
     ]
 
 
 def test_C407_enumerate_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = enumerate([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:7: C407 Unnecessary list comprehension - 'enumerate' can take a generator.",
+        "./example.py:1:7: C407 Unnecessary list comprehension - 'enumerate' "
+        + "can take a generator."
     ]
 
 
 def test_C407_tuple_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = ()
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C407_tuple_pass_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple(x for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C407_tuple_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:7: C407 Unnecessary list comprehension - 'tuple' can take a generator.",
+        "./example.py:1:7: C407 Unnecessary list comprehension - 'tuple' can "
+        + "take a generator."
     ]
 
 
 def test_it_does_not_crash_on_attribute_functions(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo
         bar = foo.baz(x for x in range(10))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_1(flake8dir):
-    flake8dir.make_example_py('()')
+    flake8dir.make_example_py("()")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_2(flake8dir):
-    flake8dir.make_example_py('[]')
+    flake8dir.make_example_py("[]")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_3(flake8dir):
-    flake8dir.make_example_py('{}')
+    flake8dir.make_example_py("{}")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_4(flake8dir):
-    flake8dir.make_example_py('set()')
+    flake8dir.make_example_py("set()")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_5(flake8dir):
-    flake8dir.make_example_py('''\
+    flake8dir.make_example_py(
+        """\
         foo = {}
         dict(bar=1, **foo)
-    ''')
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_pass_6(flake8dir):
-    flake8dir.make_example_py('''\
+    flake8dir.make_example_py(
+        """\
         foo = [1, 2]
         list(*foo)
-    ''')
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C408_fail_1(flake8dir):
-    flake8dir.make_example_py('tuple()')
+    flake8dir.make_example_py("tuple()")
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: C408 Unnecessary tuple call - rewrite as a literal.",
+        "./example.py:1:1: C408 Unnecessary tuple call - rewrite as a literal."
     ]
 
 
 def test_C408_fail_2(flake8dir):
-    flake8dir.make_example_py('list()')
+    flake8dir.make_example_py("list()")
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: C408 Unnecessary list call - rewrite as a literal.",
+        "./example.py:1:1: C408 Unnecessary list call - rewrite as a literal."
     ]
 
 
 def test_C408_fail_3(flake8dir):
-    flake8dir.make_example_py('dict()')
+    flake8dir.make_example_py("dict()")
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: C408 Unnecessary dict call - rewrite as a literal.",
+        "./example.py:1:1: C408 Unnecessary dict call - rewrite as a literal."
     ]
 
 
 def test_C408_fail_4(flake8dir):
-    flake8dir.make_example_py('dict(a=1)')
+    flake8dir.make_example_py("dict(a=1)")
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: C408 Unnecessary dict call - rewrite as a literal.",
+        "./example.py:1:1: C408 Unnecessary dict call - rewrite as a literal."
     ]
 
 
 def test_C409_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple(range)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C409_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple([])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C409 Unnecessary list passed to tuple() - rewrite as a tuple literal.',
+        "./example.py:1:7: C409 Unnecessary list passed to tuple() - rewrite as "
+        + "a tuple literal."
     ]
 
 
 def test_C409_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple([1, 2])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C409 Unnecessary list passed to tuple() - rewrite as a tuple literal.',
+        "./example.py:1:7: C409 Unnecessary list passed to tuple() - rewrite as "
+        + "a tuple literal."
     ]
 
 
 def test_C409_fail_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple(())
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C409 Unnecessary tuple passed to tuple() - remove the outer call to tuple().',
+        "./example.py:1:7: C409 Unnecessary tuple passed to tuple() - remove "
+        + "the outer call to tuple()."
     ]
 
 
 def test_C409_fail_4(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = tuple((1, 2))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C409 Unnecessary tuple passed to tuple() - remove the outer call to tuple().',
+        "./example.py:1:7: C409 Unnecessary tuple passed to tuple() - remove "
+        + "the outer call to tuple()."
     ]
 
 
 def test_C410_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list(range)
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C410_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list([])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C410 Unnecessary list passed to list() - remove the outer call to list().',
+        "./example.py:1:7: C410 Unnecessary list passed to list() - remove the "
+        + "outer call to list()."
     ]
 
 
 def test_C410_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list([1, 2])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C410 Unnecessary list passed to list() - remove the outer call to list().',
+        "./example.py:1:7: C410 Unnecessary list passed to list() - remove the "
+        + "outer call to list()."
     ]
 
 
 def test_C410_fail_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list(())
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C410 Unnecessary tuple passed to list() - rewrite as a list literal.',
+        "./example.py:1:7: C410 Unnecessary tuple passed to list() - rewrite as "
+        + "a list literal."
     ]
 
 
 def test_C410_fail_4(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         foo = list((1, 2))
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:7: C410 Unnecessary tuple passed to list() - rewrite as a list literal.',
+        "./example.py:1:7: C410 Unnecessary tuple passed to list() - rewrite as "
+        + "a list literal."
     ]
 
 
 def test_C411_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         [x for x in range(10)]
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_C411_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         list([x for x in range(10)])
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:1: C411 Unnecessary list call - remove the outer call to list().',
+        "./example.py:1:1: C411 Unnecessary list call - remove the outer call "
+        + "to list()."
     ]


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge