### PR TITLE
Add C412 rule to complain about list comprehension on rhs of 'in'

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 .. Insert new release notes below this line
 
 * Update Python support to 3.5-3.7, as 3.4 has reached its end of life.
+* ``C412`` rule that complains about using list comprehension with ``in``.
 
 2.1.0 (2019-03-01)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -135,3 +135,11 @@ It's unnecessary to use a ``list`` around list comprehension, since it is
 equivalent without it. For example:
 
 * Rewrite ``list([f(x) for x in foo])`` as ``[f(x) for x in foo]``
+
+C412: Unnecessary list comprehension - rhs of 'in' can be a generator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's unnecessary to put a list comprehension on rhs of 'in' that can take
+generators instead. For example:
+
+* Rewrite ``y in [f(x) for x in foo]`` as ``y in (f(x) for x in foo)``

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ C408 Unnecessary (dict/list/tuple) call - rewrite as a literal.
 C409 Unnecessary (list/tuple) passed to tuple() - (remove the outer call to tuple()/rewrite as a tuple literal).
 C410 Unnecessary (list/tuple) passed to list() - (remove the outer call to list()/rewrite as a list literal).
 C411 Unnecessary list call - remove the outer call to list().
+C412 Unnecessary list comprehension - 'in' can take a generator.
 ==== ====
 
 Examples
@@ -136,10 +137,10 @@ equivalent without it. For example:
 
 * Rewrite ``list([f(x) for x in foo])`` as ``[f(x) for x in foo]``
 
-C412: Unnecessary list comprehension - rhs of 'in' can be a generator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+C412: Unnecessary list comprehension - 'in' can take a generator.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It's unnecessary to put a list comprehension on rhs of 'in' that can take
-generators instead. For example:
+It's unnecessary to pass a list comprehension to 'in' that can take a
+generator instead. For example:
 
 * Rewrite ``y in [f(x) for x in foo]`` as ``y in (f(x) for x in foo)``

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -31,6 +31,7 @@ class ComprehensionChecker:
         "C409": "C409 Unnecessary {type} passed to tuple() - ",
         "C410": "C410 Unnecessary {type} passed to list() - ",
         "C411": "C411 Unnecessary list call - remove the outer call to list().",
+        "C412": "C412 Unnecessary list comprehension - rhs of 'in' can be a generator.",
     }
 
     def run(self):
@@ -154,6 +155,19 @@ class ComprehensionChecker:
                         node.lineno,
                         node.col_offset,
                         self.messages["C408"].format(type=node.func.id),
+                        type(self),
+                    )
+            elif isinstance(node, ast.Compare):
+                if (
+                    len(node.ops) == 1
+                    and isinstance(node.ops[0], ast.In)
+                    and len(node.comparators) == 1
+                    and isinstance(node.comparators[0], ast.ListComp)
+                ):
+                    yield (
+                        node.lineno,
+                        node.col_offset,
+                        self.messages["C412"],
                         type(self),
                     )
 

--- a/flake8_comprehensions.py
+++ b/flake8_comprehensions.py
@@ -31,7 +31,7 @@ class ComprehensionChecker:
         "C409": "C409 Unnecessary {type} passed to tuple() - ",
         "C410": "C410 Unnecessary {type} passed to list() - ",
         "C411": "C411 Unnecessary list call - remove the outer call to list().",
-        "C412": "C412 Unnecessary list comprehension - rhs of 'in' can be a generator.",
+        "C412": "C412 Unnecessary list comprehension - 'in' can take a generator.",
     }
 
     def run(self):

--- a/test_flake8_comprehensions.py
+++ b/test_flake8_comprehensions.py
@@ -625,3 +625,36 @@ def test_C411_fail_1(flake8dir):
         "./example.py:1:1: C411 Unnecessary list call - remove the outer call "
         + "to list()."
     ]
+
+
+def test_C412_pass_1(flake8dir):
+    flake8dir.make_example_py(
+        """
+        [] == [x for x in range(10)]
+    """
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+
+def test_C412_pass_2(flake8dir):
+    flake8dir.make_example_py(
+        """
+        10 in (x for x in range(10))
+    """
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+
+def test_C412_fail_1(flake8dir):
+    flake8dir.make_example_py(
+        """
+        10 in [x for x in range(10)]
+    """
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == [
+        "./example.py:1:1: C412 Unnecessary list comprehension - rhs of 'in' "
+        + "can be a generator."
+    ]

--- a/test_flake8_comprehensions.py
+++ b/test_flake8_comprehensions.py
@@ -655,6 +655,6 @@ def test_C412_fail_1(flake8dir):
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: C412 Unnecessary list comprehension - rhs of 'in' "
-        + "can be a generator."
+        "./example.py:1:1: C412 Unnecessary list comprehension - 'in' can "
+        + "take a generator."
     ]


### PR DESCRIPTION
This is a proposal for a new checker.

`y in [f(x) for x in foo]` can be rewritten with generator expression like `y in (f(x) for x in foo)`.
Allocation of the whole list is unnecessary.

How would you like it?