### PR TITLE
Fix flake8-comprehensions version in flake8 --version output

### DIFF
--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -16,9 +16,6 @@ bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
     # via readme-renderer
-cached-property==1.5.1 \
-    --hash=sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f \
-    --hash=sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504
 certifi==2019.9.11 \
     --hash=sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50 \
     --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef \

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -16,9 +16,6 @@ bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
     # via readme-renderer
-cached-property==1.5.1 \
-    --hash=sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f \
-    --hash=sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504
 certifi==2019.9.11 \
     --hash=sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50 \
     --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef \

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -23,9 +23,6 @@ bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
     # via readme-renderer
-cached-property==1.5.1 \
-    --hash=sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f \
-    --hash=sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504
 certifi==2019.9.11 \
     --hash=sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50 \
     --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,4 @@
 black ; python_version == '3.7.*'
-cached-property>=1.0.0,<2.0.0
 docutils
 flake8
 flake8-bugbear

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ package_dir=
 py_modules = flake8_comprehensions
 include_package_data = True
 install_requires =
-    cached-property>=1.0.0,<2.0.0
     flake8>=3.0,!=3.2.0,<4
     importlib-metadata ; python_version < "3.8"
 python_requires = >=3.5

--- a/src/flake8_comprehensions.py
+++ b/src/flake8_comprehensions.py
@@ -1,8 +1,6 @@
 import ast
 import sys
 
-from cached_property import cached_property
-
 if sys.version_info >= (3, 8):
     from importlib.metadata import version
 else:
@@ -15,10 +13,7 @@ class ComprehensionChecker:
     """
 
     name = "flake8-comprehensions"
-
-    @cached_property
-    def version(self):
-        return version("flake8-comprehensions")
+    version = version("flake8-comprehensions")
 
     def __init__(self, tree, *args, **kwargs):
         self.tree = tree

--- a/tests/test_flake8_comprehensions.py
+++ b/tests/test_flake8_comprehensions.py
@@ -1,3 +1,8 @@
+import re
+import subprocess
+import sys
+
+
 def test_C400_pass_1(flake8dir):
     flake8dir.make_example_py(
         """
@@ -706,3 +711,17 @@ def test_C412_fail_1(flake8dir):
         "./example.py:1:1: C412 Unnecessary list comprehension - 'in' can "
         + "take a generator."
     ]
+
+
+def test_version():
+    result = subprocess.run(
+        [sys.executable, "-m", "flake8", "--version"],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    assert (
+        re.search(
+            rb"\bflake8-comprehensions: [0-9]+.[0-9]+.[0-9]+\b", result.stdout, re.M
+        )
+        is not None
+    )


### PR DESCRIPTION
flake8 expects plugins to define their version as a class property. The
cached_property decorator does not work as a class property, only as an
instance property. The version was previously being displayed as:

    $ flake8 --version
    3.7.8 (flake8-comprehensions: <cached_property.cached_property object at 0x7f5b0e27a640>, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.8.0 on Linux