### PR TITLE
Update README.rst example to match modern project requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ check it is being picked up with:
 .. code-block:: sh
 
     $ flake8 --version
-    2.4.1 (pep8: 1.7.0, pyflakes: 0.8.1, flake8-comprehensions: 1.0.0, mccabe: 0.3.1) CPython 2.7.11 on Darwin
+    3.7.8 (flake8-comprehensions: 3.0.0, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.8.0 on Linux
 
 
 Rules


### PR DESCRIPTION
Python 3 and flake8 3.0.0+ are required, so use them in the example.