### PR TITLE
Check for the pattern "for var in list(iterable)"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ C413 Unnecessary reversed call around sorted() - (use sorted(..., reverse=(True/
 C414 Unnecessary (list/reversed/set/sorted/tuple) call within list/set/sorted/tuple().
 C415 Unnecessary subscript reversal of iterable within reversed/set/sorted().
 C416 Unnecessary (list/set) comprehension - rewrite using list/set().
+C417 Unnecessary list call in an iteration - remove the call to list().
 ==== ====
 
 Examples
@@ -218,3 +219,12 @@ iterable should be wrapped in ``list()`` or ``set()`` instead. For example:
 
 * Rewrite ``[x for x in iterable]`` as ``list(iterable)``
 * Rewrite ``{x for x in iterable}`` as ``set(iterable)``
+
+C416: Unnecessary (list/set) comprehension - rewrite using list/set().
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's unnecessary to call list on an iterable just before if it will only be iterated on.
+The iterable should be iterated on directly instead to keep the lazy evaluation. For example:
+
+* Rewrite ``(x * x for x in list(range(n)))`` as ``(x * x for x in range(n))``
+* Rewrite ``for x in list(iterable): do_something(x)`` as ``for x in iterable: do_something(x)``

--- a/tests/test_flake8_comprehensions.py
+++ b/tests/test_flake8_comprehensions.py
@@ -1130,3 +1130,21 @@ def test_C416_fail_2_set(flake8dir):
     assert result.out_lines == [
         "./example.py:1:1: C416 Unnecessary set comprehension - rewrite using set().",
     ]
+
+
+def test_C417_fail_1_statement(flake8dir):
+    flake8dir.make_example_py("for i in list(range(8)): print(i)")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == [
+        "./example.py:1:10: C417 Unnecessary list call in an iteration"
+        " - remove the call to list().",
+    ]
+
+
+def test_C417_fail_2_expression(flake8dir):
+    flake8dir.make_example_py("[i * i for i in list(range(8))]")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == [
+        "./example.py:1:17: C417 Unnecessary list call in an iteration"
+        " - remove the call to list().",
+    ]


### PR DESCRIPTION
Hello,
Here is a proposal to check for the anti-pattern "for var in list(iterable)" evoked in #290, in both generator expressions and for statements.
I added two basic tests, but it may be a bit light.
I arbitrarily chose the code 417 as it was the first available one in the 41x series.
I used black for the formatting and the tests all passes on python 3.8.