### PR TITLE
Add __slots__ to plugin class to reduce memory footprint

### DIFF
--- a/src/flake8_comprehensions.py
+++ b/src/flake8_comprehensions.py
@@ -15,6 +15,8 @@ class ComprehensionChecker:
     name = "flake8-comprehensions"
     version = version("flake8-comprehensions")
 
+    __slots__ = ("tree",)
+
     def __init__(self, tree, *args, **kwargs):
         self.tree = tree
 


### PR DESCRIPTION
Hi! 

First of all, thanks for creating this plugin! I've been using it for years now and it's great 👏

This PR is more of a question than a clear suggested improvement; I thought about raising an issue to discuss it, but a PR seemed more actionable in case you agree with the rationale.

## Changes

So the PR simply defines `__slots__` on the plugin class, to pre-declare the class attributes we expect and in turn, make it a *little bit* more performant.

I did some memory profiling using [memory_profiler](https://github.com/pythonprofilers/memory_profiler) and from what I can tell, this reduces the memory footprint of the plugin class by 15-20%. I also tested using `sys.getsizeof` and found basically the same results there.

The drawback of declaring `__slots__`, is of course that it prevents you from setting new instance variables during runtime, but as far as I can tell (and I could be wrong), flake8 never does this. I don't know of any other flake8-plugins that have this declared, so there could be a reason why this is a bad idea, but they are not clear to me, and the [test-suite](https://github.com/sondrelg/flake8-comprehensions/actions) seems to have passed 🎉

<br>Curious to see what your take on this is 😌  

Thanks again 👏
