### PR TITLE
Fix typo in C415 Readme Example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ It's unnecessary to reverse the order of an iterable when passing it into one of
 For example:
 
 * Rewrite ``set(iterable[::-1])`` as ``set(iterable)``
-* Rewrite ``sorted(iterable[::-1])`` as ``sorted(iterable, reverse=True)``
+* Rewrite ``sorted(iterable)[::-1]`` as ``sorted(iterable, reverse=True)``
 * Rewrite ``reversed(iterable[::-1])`` as ``iterable``
 
 C416: Unnecessary ``<list/set>`` comprehension - rewrite using ``<list/set>``\().


### PR DESCRIPTION
Fixes a typo in the ReadMe. Based on how the expression was rewritten, it seems to imply that the list should be reversed AFTER sorting, not before.