### PR TITLE
Add C420 rule

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,3 +227,15 @@ For example:
 
 * Rewrite ``all([condition(x) for x in iterable])`` as ``all(condition(x) for x in iterable)``
 * Rewrite ``any([condition(x) for x in iterable])`` as ``any(condition(x) for x in iterable)``
+
+C420 Unnecessary list comprehension in for loop rewrite as a generator.
+-----------------------------------------------------------------------
+
+It's unnecessary to iterate over a list comprehension in a for loop.
+
+This prevents short circuiting (e.g. the for loop may contain a ``break`` statement) and creates an unnecessary intermediate list.
+
+Use a generator expression instead:
+
+* Rewrite ``for x in [func(y) for y in iterable]:`` as ``for x in (func(y) for y in iterable):``
+* Rewrite ``async for x in [func(y) for y in async_gen]:`` as ``async for x in (func(y) for y in async_gen):``


### PR DESCRIPTION
For discussion...

Add a rule to recommend using generator expressions rather than list comprehensions when they are only used for iteration by a for loop e.g:

```diff
- for x in [func(y) for y in iterable]:
+ for x in (func(y) for y in iterable):
    ...
```

This is an inefficient pattern which seems to crop up every now and again.

The logic for this is similar to C419:

* List comprehensions prevent short-circuiting e.g:
   ```python
   for x in [func(y) for y in iterable]:
       if x == 42:
          break  # we didn't need to call `func(y)` for items past this point
       do_something(x)
   ```
* List comprehensions create an intermediate list object, e.g. if `iterable` is 1'000 items long, then a 1'000 item list will be created in order for the `for` loop to iterate over which is inefficient.