### PR TITLE
Add rule for dict comprehensions with constant values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Add rule C420 to check for dict comprehensions with constant values that can be replaced with a call to ``dict.fromkeys()``.
+
 3.14.0 (2023-07-10)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,9 @@
 Changelog
 =========
 
-* Add rule C420 to check for dict comprehensions with constant values that can be replaced with a call to ``dict.fromkeys()``.
+* Add rule C420 to check for dict comprehensions with constant values, encouraging replacement with ``dict.fromkeys()``.
+
+  Thanks to Tom Kuson in `PR #553 <https://github.com/adamchainz/flake8-comprehensions/pull/553>`__.
 
 3.14.0 (2023-07-10)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -227,3 +227,13 @@ For example:
 
 * Rewrite ``all([condition(x) for x in iterable])`` as ``all(condition(x) for x in iterable)``
 * Rewrite ``any([condition(x) for x in iterable])`` as ``any(condition(x) for x in iterable)``
+
+C420: Unnecessary dict comprehension - rewrite using dict.fromkeys().
+----------------------------------------------------------------------
+
+It's unnecessary to use a dict comprehension to build a dict with all values set to the same constant.
+Use ``dict.fromkeys()`` instead, which is faster.
+For example:
+
+* Rewrite ``{x: 1 for x in iterable}`` as ``dict.fromkeys(iterable, 1)``
+* Rewrite ``{x: None for x in iterable}`` as ``dict.fromkeys(iterable)``

--- a/tests/test_flake8_comprehensions.py
+++ b/tests/test_flake8_comprehensions.py
@@ -886,7 +886,7 @@ def test_C417_fail(code, failures, flake8_path):
     "code",
     [
         "dict({}, a=1)",
-        "dict({x: 1 for x in range(1)}, a=1)",
+        "dict({x: [] for x in range(1)}, a=1)",
     ],
 )
 def test_C418_pass(code, flake8_path):
@@ -960,6 +960,61 @@ def test_C419_pass(code, flake8_path):
     ],
 )
 def test_C419_fail(code, failures, flake8_path):
+    (flake8_path / "example.py").write_text(dedent(code))
+    result = flake8_path.run_flake8()
+    assert result.out_lines == failures
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "{elt: elt * 2 for elt in range(5)}",
+        "{elt: [] for elt in foo}",
+        "{elt: {1, 2, 3} for elt in ['a', 'b', 'c']}",
+        "{elt: some_func() for elt in ['a', 'b', 'c']}",
+        "{elt: SomeClass() for elt in ['a', 'b', 'c']}",
+    ],
+)
+def test_C420_pass(code, flake8_path):
+    (flake8_path / "example.py").write_text(dedent(code))
+    result = flake8_path.run_flake8()
+    assert result.out_lines == []
+
+
+@pytest.mark.parametrize(
+    "code,failures",
+    [
+        (
+            "{elt: None for elt in range(5)}",
+            [
+                "./example.py:1:1: C420 Unnecessary dict comprehension - "
+                + "rewrite using dict.fromkeys()."
+            ],
+        ),
+        (
+            "{elt: 1 for elt in foo}",
+            [
+                "./example.py:1:1: C420 Unnecessary dict comprehension - "
+                + "rewrite using dict.fromkeys()."
+            ],
+        ),
+        (
+            "{elt: 'value' for elt in ['a', 'b', 'c']}",
+            [
+                "./example.py:1:1: C420 Unnecessary dict comprehension - "
+                + "rewrite using dict.fromkeys()."
+            ],
+        ),
+        (
+            "{elt: True for elt in some_func()}",
+            [
+                "./example.py:1:1: C420 Unnecessary dict comprehension - "
+                + "rewrite using dict.fromkeys()."
+            ],
+        ),
+    ],
+)
+def test_C420_fail(code, failures, flake8_path):
     (flake8_path / "example.py").write_text(dedent(code))
     result = flake8_path.run_flake8()
     assert result.out_lines == failures


### PR DESCRIPTION
Adds `C420` that checks for dictionary comprehensions that use constant values.

Changed the fixture for `test_C418_pass` as it was failing (`dict({x: 1 for x in range(1)}, a=1)` triggers the new rule).

Closes #552.