### PR TITLE
Add rule to check for unnecessary generator expressions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Add rule C421 to check for unnecessary generator expressions, encouraging replacement with ``iter()`` or the underlying iterable directly.
+
 3.15.0 (2024-06-29)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -237,3 +237,13 @@ For example:
 
 * Rewrite ``{x: 1 for x in iterable}`` as ``dict.fromkeys(iterable, 1)``
 * Rewrite ``{x: None for x in iterable}`` as ``dict.fromkeys(iterable)``
+
+C421: Unnecessary generator expression - rewrite using iter() or use the iterable directly.
+-------------------------------------------------------------------------------------------
+
+It's unnecessary to use generator expressions to create generators that simply yield items from an iterable.
+Use ``iter()`` to get a generator from an iterable or use the underlying iterable directly, depending on the context (such as in a call to ``sorted()``, which accept an iterable).
+For example:
+
+* Rewrite ``(x for x in iterable)`` as ``iter(iterable)``
+* Rewrite ``sorted(x for x in iterable)`` as ``sorted(iterable)``

--- a/src/flake8_comprehensions/__init__.py
+++ b/src/flake8_comprehensions/__init__.py
@@ -49,6 +49,10 @@ class ComprehensionChecker:
         "C420": (
             "C420 Unnecessary {type} comprehension - rewrite using dict.fromkeys()."
         ),
+        "C421": (
+            "C421 Unnecessary generator expression - rewrite using iter() or use the "
+            + "iterable directly"
+        ),
     }
 
     def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]:
@@ -379,6 +383,26 @@ class ComprehensionChecker:
                             ),
                             type(self),
                         )
+            elif (
+                isinstance(node, ast.GeneratorExp)
+                and len(node.generators) == 1
+                and len(node.generators[0].ifs) == 0
+            ):
+                if (
+                    isinstance(node.elt, ast.Name)
+                    and isinstance(node.generators[0].target, ast.Name)
+                    and node.elt.id == node.generators[0].target.id
+                ) or (
+                    isinstance(node.elt, ast.Tuple)
+                    and isinstance(node.generators[0].target, ast.Tuple)
+                    and tuples_match(node.elt, node.generators[0].target)
+                ):
+                    yield (
+                        node.lineno,
+                        node.col_offset,
+                        self.messages["C421"],
+                        type(self),
+                    )
 
 
 def has_star_args(call_node: ast.Call) -> bool:
@@ -387,6 +411,25 @@ def has_star_args(call_node: ast.Call) -> bool:
 
 def has_double_star_args(call_node: ast.Call) -> bool:
     return any(k.arg is None for k in call_node.keywords)
+
+
+def tuples_match(lhs: ast.Tuple, rhs: ast.Tuple) -> bool:
+    if len(lhs.elts) != len(rhs.elts):
+        return False
+
+    for lhs_elt, rhs_elt in zip(lhs.elts, rhs.elts):
+        if not (
+            isinstance(lhs_elt, ast.Name)
+            and isinstance(rhs_elt, ast.Name)
+            and lhs_elt.id == rhs_elt.id
+        ) and not (
+            isinstance(lhs_elt, ast.Tuple)
+            and isinstance(rhs_elt, ast.Tuple)
+            and tuples_match(lhs_elt, rhs_elt)
+        ):
+            return False
+
+    return True
 
 
 comp_type = {

--- a/tests/test_flake8_comprehensions.py
+++ b/tests/test_flake8_comprehensions.py
@@ -1018,3 +1018,43 @@ def test_C420_fail(code, failures, flake8_path):
     (flake8_path / "example.py").write_text(dedent(code))
     result = flake8_path.run_flake8()
     assert result.out_lines == failures
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "(n**2 for n in range(10))",
+        "(n for n in range(10) if n % 2 == 0)",
+        "(y for x in xs for y in ys)",
+        "((elt, idx) for idx, elt in enumerate(xs))",
+    ],
+)
+def test_C421_pass(code, flake8_path):
+    (flake8_path / "example.py").write_text(dedent(code))
+    result = flake8_path.run_flake8()
+    assert result.out_lines == []
+
+
+@pytest.mark.parametrize(
+    "code,failures",
+    [
+        (
+            "(n for n in range(10))",
+            [
+                "./example.py:1:1: C421 Unnecessary generator expression - rewrite "
+                + "using iter() or use the iterable directly"
+            ],
+        ),
+        (
+            "((idx, elt) for idx, elt in enumerate(xs))",
+            [
+                "./example.py:1:1: C421 Unnecessary generator expression - rewrite "
+                + "using iter() or use the iterable directly"
+            ],
+        ),
+    ],
+)
+def test_C421_fail(code, failures, flake8_path):
+    (flake8_path / "example.py").write_text(dedent(code))
+    result = flake8_path.run_flake8()
+    assert result.out_lines == failures


### PR DESCRIPTION
Adds `C421` that checks for unnecessary generator expressions that simply yield items from an iterable.

This patch contains a recursive function to determine if two tuple match whilst handling nesting (for example, `(a, ((b, c) d))`). I can change it to not check nested tuples if you would rather not have that complexity.

Closes #503